### PR TITLE
Updates v1.17

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,7 +5,7 @@ require_once INCLUDE_DIR . 'class.list.php';
 
 class StatusAutoChangePluginConfig extends PluginConfig {
 
-    function pre_save($config, &$errors) {
+    function pre_save(&$config, &$errors) {
         if ($config['clientReplyStatus'] == '') {
             $errors['err'] = 'You must select a status.';
             return FALSE;

--- a/statusautochange.php
+++ b/statusautochange.php
@@ -80,8 +80,7 @@ class StatusAutoChangePlugin extends Plugin {
      *
      * @see Plugin::uninstall()
      */
-    function uninstall() {
-        $errors = array ();
+    function uninstall(&$errors) {
         parent::uninstall ( $errors );
     }
 }


### PR DESCRIPTION
-  Declaration of StatusAutoChangePluginConfig::pre_save($config, &$errors)
 must be compatible with PluginConfig::pre_save(&$config, &$errors) 
- Declaration of StatusAutoChangePlugin::uninstall() must be compatible with Plugin::uninstall(&$errors)